### PR TITLE
Add docker build setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.dockerignore
+Dockerfile
+build/
+.dart_tool/
+.git/
+.github/
+.gitignore
+.packages

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,9 @@ build/
 .github/
 .gitignore
 .packages
+docker-compose.yml
+install.sh
+LICENSE
+README.md
+server.iml
+tudo.svg

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,75 @@
+name: Build and Push Docker Images
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: write
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.10.0
+        # Workaround to fix error:
+        # failed to push: failed to copy: io: read/write on closed pipe
+        # See https://github.com/docker/build-push-action/issues/761
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        # Skip when PR from a fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate docker image tags
+        id: metadata
+        uses: docker/metadata-action@v4
+        with:
+          flavor: |
+            # Disable latest tag
+            latest=false
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/tudo_server
+          tags: |
+            # Tag with branch name
+            type=ref,event=branch
+            # Tag with pr-number
+            type=ref,event=pr
+            # Tag with git tag on release
+            type=ref,event=tag
+            type=raw,value=release,enable=${{ github.event_name == 'release' }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v4.1.1
+        with:
+          platforms: linux/amd64,linux/arm64
+          # Skip pushing when PR from a fork
+          push: ${{ !github.event.pull_request.head.repo.fork }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM dart:3@sha256:f5ce3ec89ac32a5e6ddb05a5110a5f235d4f36908ef1614b728fe7bcab9bb201 as build
+
+WORKDIR /build
+COPY pubspec.* .
+RUN dart pub get
+
+COPY . .
+RUN dart pub get --offline
+RUN dart compile exe bin/main.dart -o tudo_server
+
+FROM debian:bookworm-slim@sha256:050f00e86cc4d928b21de66096126fac52c2ea47885c232932b2e4c00f0c116d
+
+WORKDIR /app/bin
+COPY --from=build /build/tudo_server .
+
+EXPOSE 8080
+ENTRYPOINT ["/app/bin/tudo_server"]

--- a/bin/main.dart
+++ b/bin/main.dart
@@ -22,13 +22,22 @@ void main(List<String> args) async {
       exit(0);
     }
 
+    final env = Platform.environment;
+
+    final port = int.parse(env['TUDO_SERVER_PORT'] ?? result['port']);
+    final database = env['TUDO_SERVER_DB'] ?? result['db'];
+    final dbHost = env['TUDO_SERVER_DB_HOST'] ?? result['db-host'];
+    final dbPort = int.parse(env['TUDO_SERVER_DB_PORT'] ?? result['db-port']);
+    final dbUsername = env['TUDO_SERVER_DB_USERNAME'] ?? result['db-username'];
+    final dbPassword = env['TUDO_SERVER_DB_PASSWORD'] ?? result['db-password'];
+
     await TudoServer().serve(
-      port: int.parse(result['port']),
-      database: result['db'],
-      dbHost: result['db-host'],
-      dbPort: int.parse(result['db-port']),
-      dbUsername: result['db-username'],
-      dbPassword: result['db-password'],
+      port: port,
+      database: database,
+      dbHost: dbHost,
+      dbPort: dbPort,
+      dbUsername: dbUsername,
+      dbPassword: dbPassword,
     );
   } on ArgParserException catch (e) {
     print('$e\n\nOptions:\n${argParser.usage}');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   tudo_server:
-    image: ghcr.io/cachapa/tudo_server:latest
+    image: ghcr.io/cachapa/tudo_server:v35
     environment:
       TUDO_SERVER_DB: tudo
       TUDO_SERVER_DB_HOST: database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.8"
+
+services:
+  tudo_server:
+    image: ghcr.io/cachapa/tudo_server:latest
+    environment:
+      TUDO_SERVER_DB: tudo
+      TUDO_SERVER_DB_HOST: database
+      TUDO_SERVER_DB_USERNAME: tudo
+      TUDO_SERVER_DB_PASSWORD: tudo
+    depends_on:
+      - database
+    ports:
+      - 8080:8080
+    restart: always
+
+  database:
+    image: postgres:14-alpine@sha256:28407a9961e76f2d285dc6991e8e48893503cc3836a4755bbc2d40bcc272a441
+    environment:
+      POSTGRES_PASSWORD: tudo
+      POSTGRES_USER: tudo
+      POSTGRES_DB: tudo
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    restart: always
+
+volumes:
+  pgdata:


### PR DESCRIPTION
This PR adds the necessary files to build and release a docker container for tudo_server, closing #1.

The Docker build workflow creates tags on the following occasions:
* The `master` tag on pushes to the master branch.
* A `pr-num` tag on pushes to open PRs (eg `pr-2`).
* A `vnum` tag when a git tag is created (eg `v34`) (This happens automatically when you create a github release)
* The `release` tag when creating a new github release (pointing to the same version as the above `vnum`.

This PR makes a few somewhat opinionated choices:
* The `latest` tag is never pushed
* I've included a docker-compose.yml as an example setup and for easier testing of the Docker stuff.
* The tag used in the compose file is set to a specific version rather than a rolling tag like `release`.

Nb: The `v35` tag used in the compose file won't exist yet until you create a new release.

Most of this should be fairly reusable for https://github.com/cachapa/tudo/issues/30 later. 
If there is anything that you would like me to explain or change, please don't hesitate to let me know! 
