### PR TITLE
Change docker workflow release trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [master]
   release:
-    types: [published]
+    types: [released]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
It seems like the v35 release didn't trigger the docker build workflow. I'm not actually sure why, but I hope this will fix it?