### PR TITLE
Call docker release from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,3 +48,10 @@ jobs:
         with:
           tag_name: "v${{ github.run_number }}"
           release_name: "v${{ github.run_number }}"
+
+  docker_release:
+    uses: ./.github/workflows/docker.yml
+    needs: build
+    secrets: inherit
+    with:
+      ref: "v${{ github.run_number }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ concurrency:
   group: "deploy"
   cancel-in-progress: true
 
+permissions:
+  packages: write # Required for calling the docker workflow
+  contents: write # Required for creating releases
+
 jobs:
   build:
     timeout-minutes: 10

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,11 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-  release:
-    types: [released]
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,8 +24,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: Determine ref
+        id: get-ref
+        run: |
+          input_ref="${{ inputs.ref }}"
+          github_ref="${{ github.sha }}"
+          ref="${input_ref:-$github_ref}"
+          echo "ref=$ref" >> $GITHUB_OUTPUT
+          
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.get-ref.outputs.ref }}        
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.2.0
@@ -61,7 +75,7 @@ jobs:
             type=ref,event=pr
             # Tag with git tag on release
             type=ref,event=tag
-            type=raw,value=release,enable=${{ github.event_name == 'release' }}
+            type=raw,value=release,enable=${{ github.event_name == 'workflow_call' }}
 
       - name: Build and push image
         uses: docker/build-push-action@v4.1.1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Generate docker image tags
         id: metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           # Small hack to pick up the right context when called with a release tag
           context: ${{ inputs.ref != '' && 'git' || 'workflow'}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,6 +63,8 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v4
         with:
+          # Small hack to pick up the right context when called with a release tag
+          context: ${{ inputs.ref != '' && 'git' || 'workflow'}}
           flavor: |
             # Disable latest tag
             latest=false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,7 +77,7 @@ jobs:
             type=ref,event=pr
             # Tag with git tag on release
             type=ref,event=tag
-            type=raw,value=release,enable=${{ github.event_name == 'workflow_call' }}
+            type=raw,value=release,enable=${{ inputs.ref != '' }}
 
       - name: Build and push image
         uses: docker/build-push-action@v4.1.1


### PR DESCRIPTION
As discussed in #3, the docker workflow will not trigger on `release: created` as this is originating from another workflow. This PR makes it so the docker release workflow is called directly instead.

I've properly tested this on my fork this time around, so it should work now.

In the future, especially if more workflows are added on release, it might be worth refactoring this so that the workflows can all be triggered by the same event without depending on eachother, but for now that's not necessary.